### PR TITLE
Unique link if only one plugin is selected at a time

### DIFF
--- a/src/js/medium-editor-insert-plugin.js
+++ b/src/js/medium-editor-insert-plugin.js
@@ -147,7 +147,10 @@
     */
     setPlaceholders: function () {
       var that = this,
-          $el = $.fn.mediumInsert.insert.$el;
+          $el = $.fn.mediumInsert.insert.$el,
+          insertBlock = '',
+          insertImage = '<a class="images-add">Image</a>',
+          insertMap = '<a class="maps-add">Map</a>';
          
       if ($el.is(':empty')) {
         $el.html('<p><br></p>');
@@ -158,9 +161,6 @@
       
         $el.children('p').each(function () {
           if ($(this).next().hasClass('mediumInsert') === false) {
-            insertBlock = '';
-            insertImage = '<a class="images-add">Image</a>';
-            insertMap = '<a class="maps-add">Map</a>';
             if($.fn.mediumInsert.settings.images === true && $.fn.mediumInsert.settings.maps === true) {
               insertBlock = '<a class="mediumInsert-buttonsShow">Insert</a>'+
                 '<ul class="action mediumInsert-buttonsOptions">'+
@@ -234,8 +234,8 @@
         
       $el.on('click', '.mediumInsert-buttons .action a', function () {
         var action = $(this).attr('class').split('-');
-        var $placeholder = $(this).parent().parent().parent().siblings('.mediumInsert-placeholder');           
-                    
+        var $placeholder = $(this).parents('.mediumInsert-buttons').siblings('.mediumInsert-placeholder');
+        
         if ($.fn.mediumInsert[action[0]] && $.fn.mediumInsert[action[0]][action[1]]) {
           $.fn.mediumInsert[action[0]][action[1]]($placeholder);
         }


### PR DESCRIPTION
If the user just wants to insert an image or a map, no need for two clicks, one should be better. I rearranged the code to show a direct link when only one plugin is selected (image or map).
