### PR TITLE
Image upload bug

### DIFF
--- a/src/js/medium-editor-insert-images.js
+++ b/src/js/medium-editor-insert-images.js
@@ -105,8 +105,8 @@
     * @return {void}
     */
 
-    uploadCompleted: function (jqxhr) {
-      var $progress = $('.progress:first', this.$el),
+    uploadCompleted: function (jqxhr, $el) {
+      var $progress = $('.progress:first', $el),
           $img;
 
       $progress.attr('value', 100);
@@ -156,7 +156,9 @@
             xhr: xhr,
             cache: false,
             contentType: false,
-            complete: this.uploadCompleted,
+            complete: function(jqxhr){
+              that.uploadCompleted(jqxhr, that.$el);
+            },
             processData: false,
             data: this.options.formatData(file)
           });


### PR DESCRIPTION
Hi

I found that my uploaded images were never appearing after they had been successfully uploaded to the server.

It turns out that `this.$el` at https://github.com/orthes/medium-editor-insert-plugin/blob/master/src/js/medium-editor-insert-images.js#L109 was always `undefined` (since `this` means something else in the ajax complete callback) and so `var $progress = $('.progress:first', this.$el)` turned out to be selecting another progress bar I had on my page which had nothing to do with this plugin.

This pull request passes the right element into the `uploadComplete` function so that the correct progress bar is selected.

Note: I haven't yet grunted the project in this pull request, I can do that if needed.
