### PR TITLE
Add repository to package.json to prevent npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "jQuery insert plugin for MediumEditor",
   "license": "MIT",
   "homepage": "https://github.com/orthes/medium-editor-insert-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/orthes/medium-editor-insert-plugin.git"
+  },
   "author": {
     "name": "Pavel Linkesch",
     "url": "http://linkesch.sk"


### PR DESCRIPTION
`npm` require to have `repository` field in `package.json`
