### PR TITLE
Prevents default button events to have more isolated control

### DIFF
--- a/src/js/medium-editor-insert-plugin.js
+++ b/src/js/medium-editor-insert-plugin.js
@@ -424,7 +424,9 @@
         $('.mediumInsert-buttonsOptions', this).hide();
       });
 
-      $el.on('click', '.mediumInsert-buttons .mediumInsert-action', function () {
+      $el.on('click', '.mediumInsert-buttons .mediumInsert-action', function (e) {
+        e.preventDefault();
+
         var addon = $(this).data('addon'),
             action = $(this).data('action'),
             $placeholder = $(this).parents('.mediumInsert-buttons').siblings('.mediumInsert-placeholder');


### PR DESCRIPTION
On our site page reloads, when I click on media insert plugin `button`. This changes fix the problems.

I think we have some JS logic on `button`. This is our mistakes. But I think a lot of users may have this issue too, because user think about plugin like a solid element and didn’t know what tags are inside and what side effect it can create.

So I think we should make plugin more isolated with this fix.
