### PR TITLE
Prevent drop inside new block tags too

### DIFF
--- a/src/js/medium-editor-insert-plugin.js
+++ b/src/js/medium-editor-insert-plugin.js
@@ -138,7 +138,8 @@
       return this.each(function () {
         $(this).addClass('medium-editor-insert-plugin');
 
-        $('p', this).bind('dragover drop', function (e) {
+        var blocks = 'p, h1, h2, h3, h4, h5, h6, ol, ul, blockquote';
+        $(this).on('dragover drop', blocks, function (e) {
           e.preventDefault();
           return false;
         });


### PR DESCRIPTION
1. Prevent drop image inside other block tags, like in #76.
2. `$('p', this).bind` prevents only current `p` for `drop`. But if user create new paragraphs, they will be unprotected. I add delegate event listener to protect new paragraphs too.
