### PR TITLE
Move add button after added images to easy upload several images

### DIFF
--- a/src/sass/medium-editor-insert-plugin.scss
+++ b/src/sass/medium-editor-insert-plugin.scss
@@ -85,7 +85,7 @@ q, blockquote {
 .mediumInsert .mediumInsert-buttons {
   position: absolute;
   width: 40px;
-  top: 0;
+  bottom: 0;
   left: 0;
   color: #ddd;
   font-size: 0.9em; }


### PR DESCRIPTION
Now “plus” button is showed on top on `.mediumInsert` block. So, when I upload image it will be after the button.

But if I click on plus button again, it will put next uploaded image after the previous one.

So, it will be better to put plus image on botton of `.mediumInsert` block.
