### PR TITLE
Avoid error on a missing plugin

### DIFF
--- a/src/js/medium-editor-insert-plugin.js
+++ b/src/js/medium-editor-insert-plugin.js
@@ -136,9 +136,11 @@
         $.fn.mediumInsert.insert.init($(this));
 
         $.each($.fn.mediumInsert.settings.addons, function (i) {
-          var addonOptions = $.fn.mediumInsert.settings.addons[i];
-          addonOptions.$el = $.fn.mediumInsert.insert.$el;
-          addons[i].init(addonOptions);
+          if (typeof addons[i] !== 'undefined') {
+            var addonOptions = $.fn.mediumInsert.settings.addons[i];
+            addonOptions.$el = $.fn.mediumInsert.insert.$el;
+            addons[i].init(addonOptions);
+          }
         });
       });
     }
@@ -271,7 +273,11 @@
 
       if (typeof addon === 'undefined') {
         $.each($.fn.mediumInsert.settings.addons, function (i) {
-          buttons += '<li>' + addons[i].insertButton(buttonLabels) + '</li>';
+          if (typeof addons[i] === 'undefined') {
+            console.log('Addon "' + i + '" is not available. Did you forgot to include the related file?');
+          } else {
+            buttons += '<li>' + addons[i].insertButton(buttonLabels) + '</li>';
+          }
         });
       } else {
         buttons += '<li>' + addons[addon].insertButton(buttonLabels) + '</li>';
@@ -310,7 +316,7 @@
       $el.keyup(function () {
         var $lastChild = $el.children(':last'),
             i;
-        
+
         // Fix #39
         // After deleting all content (ctrl+A and delete) in Firefox, all content is deleted and only <br> appears
         // To force placeholder to appear, set <p><br></p> as content of the $el
@@ -350,7 +356,7 @@
           }
           i++;
         });
-          
+
       }).keyup();
     },
 

--- a/test/medium-editor-insert-plugin.js
+++ b/test/medium-editor-insert-plugin.js
@@ -40,7 +40,7 @@ test('customize editor\'s serialize function', function () {
 
 asyncTest('extend editor\'s deactivate function to call plugins\'s disable', function() {
   var editor = new MediumEditor('#qunit-fixture');
-  
+
   this.stub($.fn.mediumInsert.insert, 'disable', function () {
     $.fn.mediumInsert.insert.disable.restore();
     ok(true, 'disable() called');
@@ -67,7 +67,7 @@ test('editor\'s deactivate returns false if editor is not active', function() {
 
 asyncTest('extend editor\'s activate function to call plugins\'s enable', function() {
   var editor = new MediumEditor('#qunit-fixture');
-  
+
   this.stub($.fn.mediumInsert.insert, 'enable', function () {
     $.fn.mediumInsert.insert.enable.restore();
     ok(true, 'enable() called');
@@ -120,6 +120,21 @@ test('initial loop calls init functions', function() {
   ok(stub4.called, 'embeds.init() called');
 });
 
+test('initial loop with one missing plugin', function() {
+  var stub1 = this.stub($.fn.mediumInsert.insert, 'init'),
+      stub4 = this.stub($.fn.mediumInsert.getAddon('embeds'), 'init');
+
+  $('div').mediumInsert({
+    addons: {
+      embeds: {},
+      flash: {},
+    }
+  });
+
+  ok(stub1.called, 'insert.init() called');
+  ok(stub4.called, 'embeds.init() called');
+});
+
 
 /**
 * Insert
@@ -144,7 +159,7 @@ module("insert", {
 
 test('init sets el', function () {
   var $el = $('<div></div>');
-  
+
   this.stub($.fn.mediumInsert.insert, 'setPlaceholders');
 
   $.fn.mediumInsert.insert.init($el);


### PR DESCRIPTION
On adding a new plugin in the configuration, if the related file isn't include, the lib fails to start.

Instead, it displays a `console.log()` message indicating the missing plugin and does not kill the plugin. The lib will start without this plugin activated.

It can also fire an alert message but I prefer a silent `console.log()`. If this case happen, the developper will (of course) look into the console and will see the message. Tell me if you prefer an alert instead of a `console.log()` (or maybe a custom exception ?).

I've added a test to reproduce the bug.
