### PR TITLE
added check to preparePreviousImages

### DIFF
--- a/src/js/medium-editor-insert-images.js
+++ b/src/js/medium-editor-insert-images.js
@@ -133,9 +133,11 @@
     preparePreviousImages: function () {
       this.$el.find('.mediumInsert-images').each(function() {
         var $parent = $(this).parent();
-        $parent.html($.fn.mediumInsert.insert.getButtons('images') +
-          '<div class="mediumInsert-placeholder" draggable="true">' + $parent.html() + '</div>'
-        );
+        if (!$parent.hasClass('mediumInsert-placeholder')) {
+          $parent.html($.fn.mediumInsert.insert.getButtons('images') +
+            '<div class="mediumInsert-placeholder" draggable="true">' + $parent.html() + '</div>'
+          );
+        }
       });
     },
 


### PR DESCRIPTION
so it doesn't create a placeholder inside a placeholder (inception) when loaded with existing medium-editor-insert content
