### PR TITLE
Do not remove plugin on cleaning empty placeholder

### DIFF
--- a/src/js/medium-editor-insert-plugin.js
+++ b/src/js/medium-editor-insert-plugin.js
@@ -334,7 +334,13 @@
         // by removing all empty placeholders
         if (that.isFirefox){
           $('.mediumInsert .mediumInsert-placeholder:empty', $el).each(function () {
-            $(this).parent().remove();
+            var parent = $(this).parent();
+
+            // if the parent has at least one div child it means it can be a plugin, so we don't remove it
+            // for example, embed works like that (Fix #98)
+            if (0 === parent.find('.mediumInsert-buttons div').length) {
+              parent.remove();
+            }
           });
         }
 


### PR DESCRIPTION
This should fix #98

The embed plugin insert a div before the placeholder:

``` javascript
add : function ($placeholder) {
    var formHtml = '<div class="medium-editor-toolbar...';
    $(formHtml).appendTo($placeholder.prev());
```

The fix for Firefox that cleanup empty placeholder (related to #28) has to check if this `div` exists before removing it.

I've made it kind of generic by checking for a div element instead of a class.

I was thinking of a better way to tell the _placeholder cleaner_ to not remove the parent: instead of checking that a `div` has join the party, we could add a `data-` attribute to the parent (the `mediumInsert-` div) when adding the div (in the `add` method of the plugin).

``` javascript
$(formHtml).appendTo($placeholder.prev());
$placeholder.parent().data('plugin-inserted', 'embed');
```

And then, in the `placeholder cleaner` we can do that to check if we have to remove the parent :

``` javascript
if (typeof parent.data('plugin-inserted') == "undefined") {
```

It can be apply to the plugin embed and table. Which option do you prefer? Should I keep the _ugly_ fix in the 0.x branch and create the one with the data solution in the 1.x branch?
