### PR TITLE
Remove unecessary prepend

### DIFF
--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -113,8 +113,6 @@
         e.preventDefault();
         e.stopPropagation();
 
-        $place.prepend('&nbsp;');
-
         this.getCore().moveCaret($place);
     };
 


### PR DESCRIPTION
I was wondering why do you need to add one space inside the `<p>` while disabling the selection ?

Because, first I fixed multiple spaces addition (when use click a lot inside the embed placeholder) using this snippet:

``` javascript
// do not add multiple spaces, one is enough
if (0 !== $place.html().indexOf('&nbsp;')) {
    $place.prepend('&nbsp;');
}
```

And then I removed the `prepend` and everything still works... :)
