### PR TITLE
[1.0] Attempt to fix the button positioning

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -360,11 +360,11 @@
 
                 // Left position is set according to parent paragraph
                 // Top position is set according to current active element
-                left = $p.offset().left - parseInt($buttons.find('.medium-insert-buttons-addons').css('left'), 10) - parseInt($buttons.find('.medium-insert-buttons-addons a:first').css('margin-left'), 10);
+                left = $p.position().left - parseInt($buttons.find('.medium-insert-buttons-addons').css('left'), 10) - parseInt($buttons.find('.medium-insert-buttons-addons a:first').css('margin-left'), 10);
 
                 $buttons.css({
-                    left: left < 0 ? $p.offset().left : left,
-                    top: $current.offset().top
+                    left: left,
+                    top: $current.position().top + parseInt($current.css('margin-top'), 10)
                 });
 
                 if (isAddon) {


### PR DESCRIPTION
`offset()` retrieves coordinates relative to the document. In our case, Medium Insert Plugin won't stand alone in most case, it will be inside an existing system.
So we need to use `position()` because it retrieves coordinates relative to the offset parent.

From the jQuery doc:

> When positioning a new element near another one and within the same containing DOM element, .position() is the more useful

Related to #116
