### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Finally, you can initialize the insert plugin:
 
 ```javascript
 $(function () {
-    $('.editable').mediumInsert({
+    $('.editable').MediumInsert({
         editor: editor
     });
 });


### PR DESCRIPTION
The README has a lowercase 'm' that references the `MediumInsert` plugin name. I updated this for future readers. It doesn't work with a lowercase :)