### PR TITLE
fix errors on 'blur'

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -97,7 +97,7 @@
             .on('dragover drop', function (e) {
                 e.preventDefault();
             })
-            .on('blur', $.proxy(this, 'activatePlaceholder'))
+            .on('blur', $.proxy(this, 'editorActivatePlaceholder'))
             .on('keyup click', $.proxy(this, 'toggleButtons'))
             .on('selectstart mousedown', '.medium-insert, .medium-insert-buttons', $.proxy(this, 'disableSelection'))
             .on('keydown', $.proxy(this, 'fixSelectAll'))


### PR DESCRIPTION
The wrong object/method combination was being invoked on blur events, causing undefined methods to be called. The correct invocation is either [medium editor].activatePlaceholder, or [insert plugin].editorActivatePlaceholder (which alias to the same function).