### PR TITLE
Ensure core is Enabled when selectImage is called

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -377,19 +377,21 @@
      */
 
     Images.prototype.selectImage = function (e) {
-        var $image = $(e.target),
-            that = this;
-
-        // Hide keyboard on mobile devices
-        this.$el.blur();
-
-        $image.addClass('medium-insert-image-active');
-        $image.closest('.medium-insert-images').addClass('medium-insert-active');
-
-        setTimeout(function () {
-            that.addToolbar();
-            that.getCore().addCaption($image.closest('figure'), that.options.captionPlaceholder);
-        }, 50);
+        if(this.getCore().options.enabled) {
+            var $image = $(e.target),
+                that = this;
+    
+            // Hide keyboard on mobile devices
+            this.$el.blur();
+    
+            $image.addClass('medium-insert-image-active');
+            $image.closest('.medium-insert-images').addClass('medium-insert-active');
+    
+            setTimeout(function () {
+                that.addToolbar();
+                that.getCore().addCaption($image.closest('figure'), that.options.captionPlaceholder);
+            }, 50);
+        }
     };
 
     /**


### PR DESCRIPTION
Ran into an issue where I disabled (destroyed) MediumEditor and the Images were still editable when you selected them. Simple fix is to wrap selectImage in a condition.