### PR TITLE
input event not triggered after preview is swapped for the real image

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -359,17 +359,20 @@
 
     Images.prototype.showImage = function (img, data) {
         var $place = this.$el.find('.medium-insert-active'),
-            domImage;
+            domImage,
+            that;
 
         // Hide editor's placeholder
         $place.click();
 
         // If preview is allowed and preview image already exists,
         // replace it with uploaded image
+        that = this;
         if (this.options.preview && data.context) {
             domImage = this.getDOMImage();
             domImage.onload = function () {
                 data.context.find('img').attr('src', domImage.src);
+                that.$el.trigger('input');
             };
             domImage.src = img;
         } else {

--- a/test/images.js
+++ b/test/images.js
@@ -171,6 +171,36 @@ asyncTest('triggering input event on showImage', function () {
     });
 });
 
+asyncTest('triggering input event twice on showImage for preview', function (assert) {
+    var that = this,
+        inputTriggerCount = 0,
+        stubbedImage,
+        context;
+
+    stubbedImage = sinon.stub();
+    sinon.stub(this.addon, 'getDOMImage').returns(stubbedImage);
+    context = this.$el.prepend('<div class="medium-insert-images medium-insert-active">'+
+        '<figure><img src="data:" alt=""></figure>'+
+    '</div>');
+
+    assert.expect(2);
+    this.$el.on('input', function () {
+        if (inputTriggerCount === 0)
+            start();
+        if (inputTriggerCount === 2) {
+            that.$el.off('input');
+        } else {
+            inputTriggerCount++;
+        }
+        ok(1, 'input triggered');
+    });
+
+    this.addon.showImage('http://image.co', {
+        context: context
+    });
+    stubbedImage.onload();
+});
+
 test('selecting image', function () {
     this.$el.find('p')
         .addClass('medium-insert-images')


### PR DESCRIPTION
This is fixing an issue I introduced when I submitted https://github.com/orthes/medium-editor-insert-plugin/issues/132

If you are relying on the input event to determine when to save, prior to this change you had no indication that the image was done uploading. Now it will trigger an input.

The test is a little weird but I'm not very familiar with qunit/sinon tests so please let me know what I can do to improve.