### PR TITLE
Speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
+# faster builds on new travis setup not using sudo
+sudo: false
+
 language: node_js
+
 node_js:
   - "0.10"
+
 before_script:
   - npm install -g grunt-cli
   - npm install -g bower
   - bower install
+
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Use the container based infra of Travis.

This infra speed up test by starting them faster than the non-container one.
If you check http://www.traviscistatus.com/ you'll see that the non-container can form a bottleneck (usually when both US and EU are awake) while the container infra is never full.

:arrow_right: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Also, caching deps works only on the contrainer infra.