### PR TITLE
hideButtons is intern to the plugin

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -60,6 +60,7 @@
             this.options.editor._serialize = this.options.editor.serialize;
             this.options.editor._destroy = this.options.editor.destroy;
             this.options.editor._setup = this.options.editor.setup;
+            this.options.editor._hideInsertButtons = this.hideButtons;
 
             this.options.editor.serialize = this.editorSerialize;
             this.options.editor.destroy = this.editorDestroy;
@@ -186,7 +187,7 @@
 
         if (!(el.querySelector('img, blockquote')) && cloneHtml === '') {
             this.showPlaceholder(el);
-            this.hideButtons();
+            this.base._hideInsertButtons($(el));
         } else {
             this.hidePlaceholder(el);
         }


### PR DESCRIPTION
`editorUpdatePlaceholder` will be called from inside MediumEditor, since we replace it to handle custom buttons.

This means every thing inside this function should be attached to MediumEditor.
Calling a method from medium-editor-insert-plugin (hideButtons) inside this method won't work.
That's why we need to re-inject it inside MediumEditor as `_hideInsertButtons`.

I cleaned up too much things in my previous PR (#196), sorry about that.