### PR TITLE
Added deleteMethod option (#205)

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -9,6 +9,7 @@
         addonName = 'Images', // first char is uppercase
         defaults = {
             label: '<span class="fa fa-camera"></span>',
+            deleteMethod: 'POST',
             deleteScript: 'delete.php',
             preview: true,
             captions: true,
@@ -521,7 +522,14 @@
 
     Images.prototype.deleteFile = function (file) {
         if (this.options.deleteScript) {
-            $.post(this.options.deleteScript, { file: file });
+            // If deleteMethod is somehow undefined, defaults to POST
+            var method = this.options.deleteMethod || 'POST';
+
+            $.ajax({
+                url: this.options.deleteScript,
+                type: method,
+                data: { file: file }
+            });
         }
     };
 

--- a/test/images.js
+++ b/test/images.js
@@ -313,9 +313,9 @@ asyncTest('deleting file', function () {
         .append('<figure><img src="image1.jpg" alt=""></figure>'+
             '<figure><img src="image2.jpg" alt="" class="medium-insert-image-active"></figure>');
 
-    this.stub(jQuery, 'post', function () {
+    this.stub(jQuery, 'ajax', function () {
        ok(1, 'ajax call created');
-       jQuery.post.restore();
+       jQuery.ajax.restore();
        start();
     });
 


### PR DESCRIPTION
Hello,

This is the fix I propose for #205. All test passed in testem, for the following browsers:

Chrome 43.0.2357.130 (64-bit)
Safari 8.0.7 (10600.7.12)
Firefox 38.0.5

We'll need to update the documentation at the wiki too (I'd be glad to do it). Should we wait until the next version is released for that?