### PR TITLE
Add a background color to the button list

### DIFF
--- a/src/sass/_core.scss
+++ b/src/sass/_core.scss
@@ -69,6 +69,7 @@
             top: -32px;
             li {
                 display: inline-block;
+                background-color: #fff;
                 a {
                     box-sizing: border-box;
                     display: inline-block;


### PR DESCRIPTION
This white background color will then hide the cursor and avoid a _glinch_ behavior where buttons are displayed and cursor is blinking behind them.

Here is a preview:

![cursor-blink](https://cloud.githubusercontent.com/assets/62333/9520548/7e9f56e4-4cc8-11e5-8274-8612c909dd82.gif)

Fix #214 