### PR TITLE
Include option to store embed meta as json

### DIFF
--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -297,10 +297,11 @@
             },
             success: function(data) {
                 var html = data && data.html;
-		 if (that.options.storeMeta){
-                    console.log('storig meta');
+
+		if (that.options.storeMeta){
                     html+='<div class="medium-insert-meta"><script type="text/json">'+JSON.stringify(data)+'</script></div>';                    
                 }
+
                 if (data && !data.html && data.type === 'photo' && data.url) {
                     html = '<img src="' + data.url + '" alt="">';
                 }

--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -11,6 +11,7 @@
             oembedProxy: 'http://medium.iframe.ly/api/oembed?iframe=1',
             captions: true,
             captionPlaceholder: 'Type caption (optional)',
+            storeMeta:false,
             styles: {
                 wide: {
                     label: '<span class="fa fa-align-justify"></span>',
@@ -298,8 +299,8 @@
             success: function(data) {
                 var html = data && data.html;
 
-		if (that.options.storeMeta){
-                    html+='<div class="medium-insert-meta"><script type="text/json">'+JSON.stringify(data)+'</script></div>';                    
+                if (that.options.storeMeta){
+                    html += '<div class="medium-insert-embeds-meta"><script type="text/json">'+JSON.stringify(data)+'</script></div>';                    
                 }
 
                 if (data && !data.html && data.type === 'photo' && data.url) {

--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -297,7 +297,10 @@
             },
             success: function(data) {
                 var html = data && data.html;
-
+		 if (that.options.storeMeta){
+                    console.log('storig meta');
+                    html+='<div class="medium-insert-meta"><script type="text/json">'+JSON.stringify(data)+'</script></div>';                    
+                }
                 if (data && !data.html && data.type === 'photo' && data.url) {
                     html = '<img src="' + data.url + '" alt="">';
                 }


### PR DESCRIPTION
I want to resolve #235 by accepting a `storeMeta` option in the embed config that when set to `true` stores embed json in a `<script>` tag in the resulting html.

example embed config:

`````
     embeds:{
          oembedProxy:'https://www.iframely.com/iframely',
          storeMeta:true
     }
`````