### PR TITLE
multiple editor image toolbar action effects all instances bugfix

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -89,6 +89,7 @@
     function Images (el, options) {
         this.el = el;
         this.$el = $(el);
+        this.$currentImage = null;
         this.templates = window.MediumInsert.Templates;
         this.core = this.$el.data('plugin_'+ pluginName);
 
@@ -427,6 +428,8 @@
             var $image = $(e.target),
                 that = this;
 
+            this.$currentImage = $image;
+
             // Hide keyboard on mobile devices
             this.$el.blur();
 
@@ -469,6 +472,7 @@
         } else if ($el.is('figcaption') === false) {
             this.core.removeCaptions();
         }
+        this.$currentImage = null;
     };
 
     /**
@@ -595,6 +599,7 @@
      */
 
     Images.prototype.toolbarAction = function (e) {
+        if (this.$currentImage === null) return;
         var $button = $(e.target).is('button') ? $(e.target) : $(e.target).closest('button'),
             $li = $button.closest('li'),
             $ul = $li.closest('ul'),
@@ -636,6 +641,7 @@
      */
 
     Images.prototype.toolbar2Action = function (e) {
+        if (this.$currentImage === null) return;
         var $button = $(e.target).is('button') ? $(e.target) : $(e.target).closest('button'),
             callback = this.options.actions[$button.data('action')].clicked;
 


### PR DESCRIPTION
Hello everyone

I want to share something me and my team experienced. 

I have multiple .editable content on the page, I initialized multiple editor and insert plugin with something like.

    $(".editable").each(function() { ... });

My problem is: when you select an image from one instance and click an action from image toolbar that appeared. Action effects all instance photos at the same time. 
