### PR TITLE
Allow future minor versions of MediumEditor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "jquery": ">=1.9.0",
-    "medium-editor": "~5.10.0",
+    "medium-editor": "~5.10",
     "handlebars": "~4.0.0",
     "blueimp-file-upload": "~9.11.1",
     "jquery-sortable": "~0.9.12"


### PR DESCRIPTION
I was wondering why we didn't allow minor version for MediumEditor and only allow patch version?
It kinds of block new feature.