### PR TITLE
Fix #273 - call uploadCompleted() after uploaded image replaces preview

### DIFF
--- a/spec/images.spec.js
+++ b/spec/images.spec.js
@@ -160,7 +160,7 @@ describe('Images addon', function () {
         });
     });
 
-    it('truggers input event twice on showImage for preview', function (done) {
+    it('triggers input event twice on showImage for preview', function (done) {
         var inputTriggerCount = 0,
             stubbedImage = jasmine.createSpy('image'),
             context = this.$el.prepend('<div class="medium-insert-images medium-insert-active">' +
@@ -182,6 +182,38 @@ describe('Images addon', function () {
             context: context
         });
         stubbedImage.onload();
+    });
+
+    it('calls uploadCompleted when preview is enabled', function (done) {
+        var stubbedImage = jasmine.createSpy('image'),
+            context = this.$el.prepend('<div class="medium-insert-images medium-insert-active">' +
+                '<figure><img src="data:" alt=""></figure>' +
+            '</div>');
+
+        spyOn(this.addon, 'getDOMImage').and.returnValue(stubbedImage);
+
+        this.addon.options.uploadCompleted = function () {
+            expect(true).toBe(true);
+            done();
+        };
+
+        this.addon.showImage('http://image.co', {
+            context: context
+        });
+        stubbedImage.onload();
+    });
+
+    it('calls uploadCompleted when preview is disabled', function (done) {
+        this.addon.options.preview = false;
+
+        this.addon.options.uploadCompleted = function () {
+            expect(true).toBe(true);
+            done();
+        };
+
+        this.addon.showImage(null, {
+            submit: function () {}
+        });
     });
 
     it('supports selecting image', function () {
@@ -368,23 +400,6 @@ describe('Images addon', function () {
         jasmine.clock().tick(50);
 
         $('.medium-insert-images-toolbar2 .medium-editor-action').first().click();
-    });
-
-    it('calls uploadCompleted callback', function (done) {
-        this.addon.options.uploadCompleted = function () {
-            expect(true).toBe(true);
-            done();
-        };
-
-        spyOn(this.addon, 'showImage');
-
-        this.addon.uploadDone(null, {
-            result: {
-                files: [
-                    { url: 'test.jpg' }
-                ]
-            }
-        });
     });
 
     it('validatates file type on upload', function (done) {

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -342,14 +342,10 @@
      */
 
     Images.prototype.uploadDone = function (e, data) {
-        var $el = $.proxy(this, 'showImage', data.result.files[0].url, data)();
+        $.proxy(this, 'showImage', data.result.files[0].url, data)();
 
         this.core.clean();
         this.sorting();
-
-        if (this.options.uploadCompleted) {
-            this.options.uploadCompleted($el, data);
-        }
     };
 
     /**
@@ -374,8 +370,13 @@
             domImage = this.getDOMImage();
             domImage.onload = function () {
                 data.context.find('img').attr('src', domImage.src);
+
+                if (this.options.uploadCompleted) {
+                    this.options.uploadCompleted(data.context, data);
+                }
+
                 that.core.triggerInput();
-            };
+            }.bind(this);
             domImage.src = img;
         } else {
             data.context = $(this.templates['src/js/templates/images-image.hbs']({
@@ -405,6 +406,8 @@
 
             if (this.options.preview) {
                 data.submit();
+            } else if (this.options.uploadCompleted) {
+                this.options.uploadCompleted(data.context, data);
             }
         }
 


### PR DESCRIPTION
`uploadCompleted()` is called too soon when `preview` option is enabled. This PR fixes that and waits and calls `uploadCompleted()` after uploaded image replaces the preview one.