### PR TITLE
Fix working with disabled placeholder plugin

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -66,7 +66,9 @@
             this.options.editor.destroy = this.editorDestroy;
             this.options.editor.setup = this.editorSetup;
 
-            this.options.editor.getExtensionByName('placeholder').updatePlaceholder = this.editorUpdatePlaceholder;
+            if (this.options.editor.getExtensionByName('placeholder') !== undefined) {
+                this.options.editor.getExtensionByName('placeholder').updatePlaceholder = this.editorUpdatePlaceholder;
+            }
         }
     }
 


### PR DESCRIPTION
Current version is failing to initialize when MediumEditor's built-in placeholder plugin is turned off.