### PR TITLE
Fix performance

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -305,7 +305,7 @@
         $text = this.$el
             .contents()
             .filter(function () {
-                return this.nodeName === '#text' && $.trim($(this).text()) !== '';
+                return (this.nodeName === '#text' && $.trim($(this).text()) !== '') || this.nodeName.toLowerCase() === 'br';
             });
 
         $text.each(function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -296,11 +296,7 @@
             return;
         }
 
-        // Fix #39
-        // After deleting all content (ctrl+A and delete) in Firefox, all content is deleted and only <br> appears
-        // To force placeholder to appear, set <p><br></p> as content of the $el
-
-        if (this.$el.html().trim() === '' || this.$el.html().trim() === '<br>') {
+        if (this.$el.children().length === 0) {
             this.$el.html(this.templates['src/js/templates/core-empty-line.hbs']().trim());
         }
 


### PR DESCRIPTION
When dealing with huge amount of data (for example when preview images are inserted as BLOB), `innerHTML` and thus `.html()` is very slow.

We're calling `Core.clean()` on every `keyup` and so is the `.html()` called every time. In this PR I simply replaced `.html()` with `.children()` to see if the content is empty or not.