### PR TITLE
avoid error on editorDestroy and editorSetup

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -158,7 +158,9 @@
 
     Core.prototype.editorDestroy = function () {
         $.each(this.elements, function (key, el) {
-            $(el).data('plugin_' + pluginName).disable();
+            if ($(el).data('plugin_' + pluginName) instanceof Core) {
+                $(el).data('plugin_' + pluginName).disable();
+            }
         });
 
         this._destroy();
@@ -174,7 +176,9 @@
         this._setup();
 
         $.each(this.elements, function (key, el) {
-            $(el).data('plugin_' + pluginName).enable();
+            if ($(el).data('plugin_' + pluginName) instanceof Core) {
+                $(el).data('plugin_' + pluginName).enable();
+            }
         });
     };
 


### PR DESCRIPTION
In my case I share one instance of MediumEditor between different DOM elements and some of these elements have the InsertPlugin initialized and others don't. So when you destroy/setup the MediumEditor instance, it fails at disabling/enabling the InsertPlugin for the elements that don't have the plugin initialized (`$(el).data('plugin_' + pluginName)` is `undefined`).