### PR TITLE
extend editor's functions only once

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -57,9 +57,15 @@
 
         // Extend editor's functions
         if (this.options && this.options.editor) {
-            this.options.editor._serialize = this.options.editor.serialize;
-            this.options.editor._destroy = this.options.editor.destroy;
-            this.options.editor._setup = this.options.editor.setup;
+            if (this.options.editor._serialize === undefined) {
+                this.options.editor._serialize = this.options.editor.serialize;
+            }
+            if (this.options.editor._destroy === undefined) {
+                this.options.editor._destroy = this.options.editor.destroy;
+            }
+            if (this.options.editor._setup === undefined) {
+                this.options.editor._setup = this.options.editor.setup;
+            }
             this.options.editor._hideInsertButtons = this.hideButtons;
 
             this.options.editor.serialize = this.editorSerialize;


### PR DESCRIPTION
same context as #310, this avoid infinite loop on editorSerialize, editorDestroy and editorSetup, as we don't reset the editor's functions by the already extended ones
(sorry for the double PR)