### PR TITLE
Hide controls and placeholder when editable area loses focus

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -505,7 +505,7 @@
             $buttons.css(position);
         }
     };
-    
+
     /*
      * Handles blur events by hiding buttons and placeholder text so they don't populate
      * the textarea content if a form is submitted in the middle of editing.
@@ -513,8 +513,8 @@
      * @return {void}
      */
     Core.prototype.handleBlur = function () {
-      this.hideButtons(this.$el);
-      this.triggerInput();
+        this.hideButtons(this.$el);
+        this.triggerInput();
     }
 
     /**

--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -237,7 +237,7 @@
         } else {
             this.removePlaceholder();
         }
-     };
+    };
 
     /**
      * Removes the placeholder text.
@@ -245,7 +245,7 @@
      * @return {void}
      */
     Embeds.prototype.removePlaceholder = function () {
-      this.$el.find('.medium-insert-embeds-active').remove();
+        this.$el.find('.medium-insert-embeds-active').remove();
     }
 
     /**


### PR DESCRIPTION
When a user is in the process of embedding / inserting something (e.g. the insert controls and/or placeholder text are visible) and then submits the form, medium-editor will write the control or placeholder tags into the textarea, and they get submitted with the form.

This is a problem, so this patch ensures that when the editable area loses focus, an incomplete insert procedure is cancelled and the controls are hidden.