### PR TITLE
Bower and grunt should be dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "jquery-sortable": "~0.9.12"
   },
   "devDependencies": {
+    "bower": "^1.7.9",
     "grunt": "~0.4.4",
     "grunt-autoprefixer": "^3.0.1",
     "grunt-banner": "^0.6.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-handlebars": "^0.11.0",
     "grunt-contrib-jasmine": "^0.9.2",


### PR DESCRIPTION
Since you are using Bower for package management and Grunt for automating development tasks, they should be installed as one of the dev dependencies.