### PR TITLE
look at html().length instead of children().length

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -308,7 +308,7 @@
             return;
         }
 
-        if (this.$el.children().length === 0) {
+        if (this.$el.html().length === 0) {
             this.$el.html(this.templates['src/js/templates/core-empty-line.hbs']().trim());
         }
 


### PR DESCRIPTION
With a plain medium editor (not using medium-editor-insert-plugin), I can set the content to plain text without any html tags, and everything just works.  Here is an example of the plain medium editor working in this way: http://codepen.io/anon/pen/EZrgYQ However, when I try to do this with a medium editor that has the insert plugin enabled, the insert plugin clears out my text. On line [311 of core.js](https://github.com/orthes/medium-editor-insert-plugin/blob/master/src/js/core.js#L311), if you change children() to html(), it will fix this issue.  