### PR TITLE
Restore original options editor on core init

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -51,6 +51,7 @@
         }
         this.options = $.extend(true, {}, defaults, options);
         this.options.editor = editor;
+        options.editor = editor; // Restore original object definition
 
         this._defaults = defaults;
         this._name = pluginName;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -51,7 +51,8 @@
         }
         this.options = $.extend(true, {}, defaults, options);
         this.options.editor = editor;
-        options.editor = editor; // Restore original object definition
+        if (options)
+            options.editor = editor; // Restore original object definition
 
         this._defaults = defaults;
         this._name = pluginName;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -51,8 +51,9 @@
         }
         this.options = $.extend(true, {}, defaults, options);
         this.options.editor = editor;
-        if (options)
+        if (options) {
             options.editor = editor; // Restore original object definition
+        }
 
         this._defaults = defaults;
         this._name = pluginName;


### PR DESCRIPTION
Having issues with a workaround put into medium editor `core.js`.  I, unexpectedly, can't re-use my options object because `editor` is unexpectedly set (and left) as null.  Current workaround:

    var options = { ... }
    var editor = { my Medium editor }
    Object.defineProperty(options, 'editor', {
      get: function() { return editor; },
      set: function(value) { } //Ignore for write only, non-strict
    });
