### PR TITLE
deleteScript can now be a callback

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -546,7 +546,7 @@
 
             if (images.length) {
                 for (i = 0; i < images.length; i++) {
-                    this.deleteFile(images[i].attr('src'));
+                    this.deleteFile(images[i]);
 
                     $parent = images[i].closest('.medium-insert-images');
                     images[i].closest('figure').remove();
@@ -577,17 +577,24 @@
     /**
      * Makes ajax call to deleteScript
      *
-     * @param {String} file File name
+     * @param {jQuery} $file The jQuery element of the file to delete
      * @returns {void}
      */
 
-    Images.prototype.deleteFile = function (file) {
+    Images.prototype.deleteFile = function ($file) {
+        // only take action if there is a truthy value
         if (this.options.deleteScript) {
-            $.ajax($.extend(true, {}, {
-                url: this.options.deleteScript,
-                type: this.options.deleteMethod || 'POST',
-                data: { file: file }
-            }, this.options.fileDeleteOptions));
+            // try to run it as a callback
+            if (typeof this.options.deleteScript === 'function') {
+                this.options.deleteScript($file);
+            // otherwise, it's probably a string, call it as ajax
+            } else {
+                $.ajax($.extend(true, {}, {
+                    url: this.options.deleteScript,
+                    type: this.options.deleteMethod || 'POST',
+                    data: { file: $file.attr('src') }
+                }, this.options.fileDeleteOptions));
+            }
         }
     };
 

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -546,7 +546,7 @@
 
             if (images.length) {
                 for (i = 0; i < images.length; i++) {
-                    this.deleteFile(images[i]);
+                    this.deleteFile(images[i].attr('src'), images[i]);
 
                     $parent = images[i].closest('.medium-insert-images');
                     images[i].closest('figure').remove();
@@ -577,22 +577,23 @@
     /**
      * Makes ajax call to deleteScript
      *
-     * @param {jQuery} $file The jQuery element of the file to delete
+     * @param {string} file The name of the file to delete
+     * @param {jQuery} $el The jQuery element of the file to delete
      * @returns {void}
      */
 
-    Images.prototype.deleteFile = function ($file) {
+    Images.prototype.deleteFile = function (file, $el) {
         // only take action if there is a truthy value
         if (this.options.deleteScript) {
             // try to run it as a callback
             if (typeof this.options.deleteScript === 'function') {
-                this.options.deleteScript($file);
+                this.options.deleteScript(file, $el);
             // otherwise, it's probably a string, call it as ajax
             } else {
                 $.ajax($.extend(true, {}, {
                     url: this.options.deleteScript,
                     type: this.options.deleteMethod || 'POST',
-                    data: { file: $file.attr('src') }
+                    data: { file: file }
                 }, this.options.fileDeleteOptions));
             }
         }


### PR DESCRIPTION
Not that anyone asked for it to my knowledge, but this is a handy option that I'm using on my server.

The signature of `Image.deleteFile` changed to take the jQuery element, instead of src. It now checks if your `deleteScript` option is a function, and if so passes the element to the callback allowing the end developer to get whatever info they need from the element and make their own AJAX call, if they desire.

The other delete options are ignored in this case, and it is up to the end developer to handle their AJAX options.

---

Use case: I'm using an API to handle my images that requires making a request like `DELETE /api/v1/image/42`, where `42` is the image's unique id. This is very difficult to do under the current structure. This modification allows you tons of freedom when deleting. If you want to use the old behavior, your code need not change.

**I have never worked on a JS project, please be gentle.**