### PR TITLE
Added option to create image URL from the upload response

### DIFF
--- a/spec/images.spec.js
+++ b/spec/images.spec.js
@@ -59,6 +59,26 @@ describe('Images addon', function () {
         expect(this.$el.find('.medium-insert-images img').attr('src')).toEqual('test.jpg');
     });
 
+    it('replaces preview by uploaded image, with user built url', function () {
+        var stubbedImage = jasmine.createSpy('image');
+        spyOn(this.addon, 'getDOMImage').and.returnValue(stubbedImage);
+        spyOn(this.addon.options, 'returnURLFromUploadResult').and.callFake(function (result) {
+            return result.success[0].id;
+        });
+        this.$el.prepend('<div class="medium-insert-images medium-insert-active"><figure><img src="data:" alt=""></figure></div>');
+
+        this.addon.uploadDone(null, {
+            context: this.$el.find('figure'),
+            result: {
+                success: [
+                    { id: 'test-image-url.jpg' }
+                ]
+            }
+        });
+        stubbedImage.onload();
+        expect(this.$el.find('.medium-insert-images img').attr('src')).toEqual('test-image-url.jpg');
+    });
+
     it('uploads without preview when it is set like this in options', function (done) {
         var $p = this.$el.find('p');
 

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -72,6 +72,9 @@
             messages: {
                 acceptFileTypesError: 'This file is not in a supported format: ',
                 maxFileSizeError: 'This file is too big: '
+            },
+            returnURLFromUploadResult: function (result) {
+                return result.files[0].url;
             }
             // uploadError: function($el, data) {}
             // uploadCompleted: function ($el, data) {}
@@ -361,7 +364,16 @@
      */
 
     Images.prototype.uploadDone = function (e, data) {
-        $.proxy(this, 'showImage', data.result.files[0].url, data)();
+
+        var url = '';
+
+        if (typeof this.options.returnURLFromUploadResult === 'function') {
+            url = this.options.returnURLFromUploadResult(data.result);
+        } else {
+            url = defaults.returnURLFromUploadResult(data.result);
+        }
+
+        $.proxy(this, 'showImage', url, data)();
 
         this.core.clean();
         this.sorting();


### PR DESCRIPTION
| Q                | A                                                       |
| ---------------- | ------------------------------------------------------- |
| Bug fix?         | no                                                  |
| New feature?     | yes                                                  |
| BC breaks?       | no                                                  |
| Deprecations?    | no                                                  |
| New tests added? | yes                                          |
| Fixed tickets    | 0 |
| License          | MIT                                                     |

**Description**
Added a new option, `returnURLFromUploadResult` to create image URL from the upload response.
Current code expects the server response to be in a certain format. 
In my case, server response is generic & used by make other places in the application.
But it is not in `files: [{url}]` format.

Provided a fallback based solution. If the `returnURLFromUploadResult` is defined, then upload result will be passed to that function & return value is used to set the url.

--

**Please, don't submit `/dist` files with your PR!**
