### PR TITLE
Fix instagram multiple embed render problem

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,6 @@
     "globals": {
         "MediumEditor": true
     },
-
     "predef": {
         "jQuery": false,
         "document": false,
@@ -16,6 +15,7 @@
         "sinon": false,
         "alert": false,
         "FB": false,
+        "instgrm": false,
         "describe": false,
         "it": false,
         "expect": false,
@@ -27,11 +27,9 @@
         "require": false,
         "dataURItoBlob": false
     },
-
-    "jquery" : true,
-    "browser" : true,
-
-    "boss" : false,
+    "jquery": true,
+    "browser": true,
+    "boss": false,
     "curly": false,
     "debug": false,
     "devel": false,

--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -466,6 +466,14 @@
                     }, 2000);
                 }
             }
+
+            if (html.indexOf('instagram') !== -1) {
+                if (typeof instgrm !== 'undefined') {
+                    setTimeout(function () {
+                        instgrm.Embeds.process();
+                    }, 0)
+                }
+            }
         }
     };
 

--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -471,7 +471,7 @@
                 if (typeof instgrm !== 'undefined') {
                     setTimeout(function () {
                         instgrm.Embeds.process();
-                    }, 0)
+                    }, 0);
                 }
             }
         }


### PR DESCRIPTION
| Q                | A                                                       |
| ---------------- | ------------------------------------------------------- |
| Bug fix?         | yes                                                  |
| New feature?     | no                                                  |
| BC breaks?       | no                                                  |
| Deprecations?    | no                                                  |
| New tests added? | not needed                                          |
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any |
| License          | MIT                                                     |

**Description**
When embed multiple instagram, first embedding is successful. But all after first one is not rendered correctly. By following instagram's instruction [link](https://developers.facebook.com/docs/instagram/embedding/) It should call 'instgrm.Embeds.process()' at every embedding.

--

**Please, don't submit `/dist` files with your PR!**
